### PR TITLE
add plot of relationship audit log reasons

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -29,6 +29,7 @@ bb_rel_status_map = {
     70: "ReadyForDeletion",
 }
 
+# See https://github.com/nmshd/backbone/blob/main/Modules/Synchronization/src/Synchronization.Domain/Entities/DatawalletModification.cs
 bb_datawallet_modification_type_map = {
     0: "Create",
     1: "Update",
@@ -36,14 +37,14 @@ bb_datawallet_modification_type_map = {
     3: "CacheChanged",
 }
 
-# See https://github.com/nmshd/backbone/blob/9f72386994f343b548e0ba694f45ab2b1b7d023a/Modules/Devices/src/Devices.Domain/Entities/Identities/Identity.cs#L343
+# See https://github.com/nmshd/backbone/blob/main/Modules/Devices/src/Devices.Domain/Entities/Identities/Identity.cs
 bb_id_status_map = {
     0: "Active",
     1: "ToBeDeleted",
     2: "Deleting",
 }
 
-# See https://github.com/nmshd/backbone/commit/5428a91ce549f996f616f0610a3a46d3de546a32#diff-fc8cc975a5ea3bd621080a4a1b318d0a0f2ce9b99ce283931ff0d84a357d4671
+# See https://github.com/nmshd/backbone/blob/main/Modules/Synchronization/src/Synchronization.Domain/Entities/Sync/ExternalEvent.cs
 bb_external_event_type_map = {
     0: "MessageReceived",
     1: "MessageDelivered",
@@ -56,11 +57,27 @@ bb_external_event_type_map = {
     8: "PeerDeleted",
 }
 
+# FIXME: Relevanten Backbone Sourcecode verlinken
 bb_datawallet_modification_collections = [
     "Tokens", "Notifications", "IdentityDeletionProcess",
     "Templates", "Settings", "Secrets", "Requests", "Relationships",
     "Messages", "Files", "Devices", "Attributes",
 ]
+
+# See https://github.com/nmshd/backbone/blob/main/Modules/Relationships/src/Relationships.Domain/Aggregates/Relationships/RelationshipAuditLogEntryReason.cs
+bb_relationship_audit_log_reason_map = {
+    0: "Creation",
+    1: "AcceptanceOfCreation",
+    2: "RejectionOfCreation",
+    3: "RevocationOfCreation",
+    4: "Termination",
+    5: "ReactivationRequested",
+    6: "AcceptanceOfReactivation",
+    7: "RejectionOfReactivation",
+    8: "RevocationOfReactivation",
+    9: "Decomposition",
+    10: "DecompositionDueToIdentityDeletion",
+}
 
 
 def is_app_client(client_id: str) -> bool:

--- a/src/dashboard/__init__.py
+++ b/src/dashboard/__init__.py
@@ -438,6 +438,16 @@ class DashboardApp:
             return plots.rlt_validity_period(df)
 
         @self._app.callback(
+            Output({"type": "graph", "plot": "ral-reasons"}, "figure"),
+            Input({"type": "hide-test-clients-checkbox", "plot": "ral-reasons"}, "value"),
+        )
+        def ral_reasons(hide_list: list | None) -> go.Figure:
+            hide = hide_list is not None and len(hide_list) > 0
+            with self._grab_cnxn() as cnxn:
+                df = queries.ral_reasons(cnxn, hide)
+            return plots.ral_reasons(df)
+
+        @self._app.callback(
             Output("hide-test-clients-radio-group", "value"),
             Output({"type": "hide-test-clients-checkbox", "plot": ALL}, "value"),
             Input("hide-test-clients-radio-group", "value"),

--- a/src/dashboard/pages/relationships.py
+++ b/src/dashboard/pages/relationships.py
@@ -110,5 +110,30 @@ layout = html.Div(
             id="num_peers_per_identity$div",
             className="graph-div",
         ),
+        html.Div(
+            [
+                html.Div(
+                    children=[
+                        _get_dropdown(
+                            children=[
+                                dcc.Checklist(
+                                    id={"type": "hide-test-clients-checkbox", "plot": "ral-reasons"},
+                                    options=[{"label": "Hide Test Clients?", "value": "hide_test_clients"}],
+                                    value=[],
+                                ),
+                            ]
+                        ),
+                        html.Span(
+                            children=["Distribution of Relationship Audit Log Reasons"],
+                            className="plot-title",
+                        ),
+                    ],
+                    className="plot-header",
+                ),
+                dcc.Graph(id={"type": "graph", "plot": "ral-reasons"}),
+            ],
+            id="ral_reasons$div",
+            className="graph-div",
+        ),
     ]
 )

--- a/src/plotly_plots.py
+++ b/src/plotly_plots.py
@@ -1325,3 +1325,32 @@ def rlt_validity_period(df: pd.DataFrame) -> go.Figure:
         showlegend=False,
     )
     return p
+
+
+def ral_reasons(df: pd.DataFrame) -> go.Figure:
+    """
+    Accepts a dataframe with the following columns:
+    - Reason: category (ordered)
+    """
+
+    if len(df) == 0:
+        return no_data()
+
+    df = df.filter(["Reason"])
+    df = df.groupby(["Reason"], as_index=False, observed=True).value_counts()
+
+    p = px.bar(
+        df,
+        x="count",
+        y="Reason",
+        log_x=True,
+        labels={
+            "count": "No. Audit Log Entries",
+            "Reason": "Audit Log Reason",
+        },
+        category_orders={
+            "Reason": df["Reason"].cat.categories,
+        },
+        color_discrete_sequence=default_color_seq,
+    )
+    return p


### PR DESCRIPTION
Neuer Plot für die Ursache eines Relationship Audit Log Eintrags (_Relationships.RelationshipAuditLog::Reason_):

  ![image](https://github.com/user-attachments/assets/bbfd588f-ca55-4b71-924b-099838377f4d)

Ich habe mich bei der Benennung der Query- und Plotfunktion an die Nomenklatur des Backends gehalten, die den IDs von Relationship Audit Logs das Präfix _RAL_ zuweist.

Zusätzlich ist an drei Stellen der Link zum Quelltext der Enums, die wir aus der C#-Codebase des Backends mappen, korrigiert (direkt nen Fehler gefunden - unser Mapping der External Event Types ist falsch - fixe ich im Anschluss dieses PRs).